### PR TITLE
Fix image not found error when pushing to ghcr

### DIFF
--- a/.github/workflows/systems-nightly.yml
+++ b/.github/workflows/systems-nightly.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fixes
 
   workflow_dispatch:
 

--- a/.github/workflows/systems-nightly.yml
+++ b/.github/workflows/systems-nightly.yml
@@ -27,146 +27,146 @@ jobs:
           nix_path: nixpkgs=channel:nixos-24.05
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Nix build
-  #       run: |
-  #         nix-build --out-link result/javascript images/javascript.nix
+      - name: Nix build
+        run: |
+          nix-build --out-link result/javascript images/javascript.nix
 
-  #     - name: Load image
-  #       run: |
-  #         docker load -i result/javascript
+      - name: Load image
+        run: |
+          docker load -i result/javascript
 
-  #     - name: Run test
-  #       run: |
-  #         output=$(echo '{
-  #           "language": "javascript",
-  #           "files": [{
-  #             "name": "main.js",
-  #             "content": "console.log(\"Hello World!\");"
-  #           }]
-  #         }' | docker run --rm -i --read-only --tmpfs /tmp:rw,noexec,nosuid,size=65536k --tmpfs /home/rce:rw,exec,nosuid,uid=1000,gid=1000,size=131072k -u rce -w /home/rce rce/javascript:latest)
+      - name: Run test
+        run: |
+          output=$(echo '{
+            "language": "javascript",
+            "files": [{
+              "name": "main.js",
+              "content": "console.log(\"Hello World!\");"
+            }]
+          }' | docker run --rm -i --read-only --tmpfs /tmp:rw,noexec,nosuid,size=65536k --tmpfs /home/rce:rw,exec,nosuid,uid=1000,gid=1000,size=131072k -u rce -w /home/rce rce/javascript:latest)
 
-  #         echo "Output: ${output}"
+          echo "Output: ${output}"
 
-  #         if [[ "${output}" == *"Hello World!"* ]]; then
-  #           echo "Test passed."
-  #         else
-  #           echo "Test failed."
-  #           exit 1
-  #         fi
+          if [[ "${output}" == *"Hello World!"* ]]; then
+            echo "Test passed."
+          else
+            echo "Test failed."
+            exit 1
+          fi
 
-  # paths-filter:
-  #   name: Paths Filter
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     images: ${{ steps.changes.outputs.images }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  paths-filter:
+    name: Paths Filter
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.changes.outputs.images }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Check for changes in paths
-  #       uses: dorny/paths-filter@v3
-  #       id: changes
-  #       with:
-  #         filters: |
-  #           images:
-  #             - 'images/**'
+      - name: Check for changes in paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            images:
+              - 'images/**'
 
   build_batch_1:
     name: Build Batch 1
-    # needs:
-    #   - test
-    #   - paths-filter
-    # if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
     uses: ./.github/workflows/template.yml
     with:
       batch_number: 1
 
-  # build_batch_2:
-  #   name: Build Batch 2
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 2
+  build_batch_2:
+    name: Build Batch 2
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 2
 
-  # build_batch_3:
-  #   name: Build Batch 3
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 3
+  build_batch_3:
+    name: Build Batch 3
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 3
 
-  # build_batch_4:
-  #   name: Build Batch 4
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 4
+  build_batch_4:
+    name: Build Batch 4
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 4
 
-  # build_batch_5:
-  #   name: Build Batch 5
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 5
+  build_batch_5:
+    name: Build Batch 5
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 5
 
-  # build_batch_6:
-  #   name: Build Batch 6
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 6
+  build_batch_6:
+    name: Build Batch 6
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 6
 
-  # build_batch_7:
-  #   name: Build Batch 7
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 7
+  build_batch_7:
+    name: Build Batch 7
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 7
 
-  # build_batch_8:
-  #   name: Build Batch 8
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 8
+  build_batch_8:
+    name: Build Batch 8
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 8
 
-  # build_batch_9:
-  #   name: Build Batch 9
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 9
+  build_batch_9:
+    name: Build Batch 9
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 9
 
-  # build_batch_10:
-  #   name: Build Batch 10
-  #   needs:
-  #     - test
-  #     - paths-filter
-  #   if: ${{ needs.paths-filter.outputs.images == 'true' }}
-  #   uses: ./.github/workflows/template.yml
-  #   with:
-  #     batch_number: 10
+  build_batch_10:
+    name: Build Batch 10
+    needs:
+      - test
+      - paths-filter
+    if: ${{ needs.paths-filter.outputs.images == 'true' }}
+    uses: ./.github/workflows/template.yml
+    with:
+      batch_number: 10

--- a/.github/workflows/systems-nightly.yml
+++ b/.github/workflows/systems-nightly.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Nix build
         run: |
-          nix-build --out-link result/javascript images/javascript.nix
+          nix-build --out-link result/rce-images-javascript images/javascript.nix
 
       - name: Load image
         run: |

--- a/.github/workflows/systems-nightly.yml
+++ b/.github/workflows/systems-nightly.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Load image
         run: |
-          docker load -i result/javascript
+          docker load -i result/rce-images-javascript
 
       - name: Run test
         run: |
@@ -43,7 +43,7 @@ jobs:
               "name": "main.js",
               "content": "console.log(\"Hello World!\");"
             }]
-          }' | docker run --rm -i --read-only --tmpfs /tmp:rw,noexec,nosuid,size=65536k --tmpfs /home/rce:rw,exec,nosuid,uid=1000,gid=1000,size=131072k -u rce -w /home/rce rce/javascript:latest)
+          }' | docker run --rm -i --read-only --tmpfs /tmp:rw,noexec,nosuid,size=65536k --tmpfs /home/rce:rw,exec,nosuid,uid=1000,gid=1000,size=131072k -u rce -w /home/rce ghcr.io/toolkithub/rce-images-javascript:edge)
 
           echo "Output: ${output}"
 

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -8,10 +8,6 @@ on:
         required: true
         type: string
 
-env:
-  REGISTRY: ghcr.io
-  GHCR_URI: ghcr.io/${{ github.repository }}
-
 permissions:
   contents: read
   packages: write
@@ -20,12 +16,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      # - name: Free up disk space
-      #   uses: jlumbroso/free-disk-space@main
-      #   with:
-      #     # this might remove tools that are actually needed,
-      #     # if set to "true" but frees about 6 GB
-      #     tool-cache: true
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: true
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -49,7 +45,7 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/images/assembly.nix
+++ b/images/assembly.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-assembly";
+  name = "ghcr.io/toolkithub/rce-images-assembly";
 
   installedPackages = [
     pkgs.binutils

--- a/images/assembly.nix
+++ b/images/assembly.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/assembly";
+  name = "ghcr.io/toolkithub/rce-image-assembly";
 
   installedPackages = [
     pkgs.binutils

--- a/images/ats.nix
+++ b/images/ats.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/ats";
+  name = "ghcr.io/toolkithub/rce-image-ats";
 
   installedPackages = [
     pkgs.gcc

--- a/images/ats.nix
+++ b/images/ats.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-ats";
+  name = "ghcr.io/toolkithub/rce-images-ats";
 
   installedPackages = [
     pkgs.gcc

--- a/images/bash.nix
+++ b/images/bash.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-bash";
+  name = "ghcr.io/toolkithub/rce-images-bash";
 
   installedPackages = [
     pkgs.procps

--- a/images/bash.nix
+++ b/images/bash.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/bash";
+  name = "ghcr.io/toolkithub/rce-image-bash";
 
   installedPackages = [
     pkgs.procps

--- a/images/clang.nix
+++ b/images/clang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-clang";
+  name = "ghcr.io/toolkithub/rce-images-clang";
 
   installedPackages = [
     pkgs.clang

--- a/images/clang.nix
+++ b/images/clang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/clang";
+  name = "ghcr.io/toolkithub/rce-image-clang";
 
   installedPackages = [
     pkgs.clang

--- a/images/clisp.nix
+++ b/images/clisp.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-clisp";
+  name = "ghcr.io/toolkithub/rce-images-clisp";
 
   installedPackages = [
     pkgs.sbcl

--- a/images/clisp.nix
+++ b/images/clisp.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/clisp";
+  name = "ghcr.io/toolkithub/rce-image-clisp";
 
   installedPackages = [
     pkgs.sbcl

--- a/images/clojure.nix
+++ b/images/clojure.nix
@@ -10,7 +10,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-clojure";
+  name = "ghcr.io/toolkithub/rce-images-clojure";
 
   installedPackages = [
     pkgs.clojure

--- a/images/clojure.nix
+++ b/images/clojure.nix
@@ -10,7 +10,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/clojure";
+  name = "ghcr.io/toolkithub/rce-image-clojure";
 
   installedPackages = [
     pkgs.clojure

--- a/images/cobol.nix
+++ b/images/cobol.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/cobol";
+  name = "ghcr.io/toolkithub/rce-image-cobol";
 
   installedPackages = [
     pkgs.gcc

--- a/images/cobol.nix
+++ b/images/cobol.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-cobol";
+  name = "ghcr.io/toolkithub/rce-images-cobol";
 
   installedPackages = [
     pkgs.gcc

--- a/images/coffeescript.nix
+++ b/images/coffeescript.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-coffeescript";
+  name = "ghcr.io/toolkithub/rce-images-coffeescript";
 
   installedPackages = [
     pkgs.nodePackages.coffee-script

--- a/images/coffeescript.nix
+++ b/images/coffeescript.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/coffeescript";
+  name = "ghcr.io/toolkithub/rce-image-coffeescript";
 
   installedPackages = [
     pkgs.nodePackages.coffee-script

--- a/images/crystal.nix
+++ b/images/crystal.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-crystal";
+  name = "ghcr.io/toolkithub/rce-images-crystal";
 
   installedPackages = [
     pkgs.crystal

--- a/images/crystal.nix
+++ b/images/crystal.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/crystal";
+  name = "ghcr.io/toolkithub/rce-image-crystal";
 
   installedPackages = [
     pkgs.crystal

--- a/images/csharp.nix
+++ b/images/csharp.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/csharp";
+  name = "ghcr.io/toolkithub/rce-image-csharp";
 
   installedPackages = [
     pkgs.mono

--- a/images/csharp.nix
+++ b/images/csharp.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-csharp";
+  name = "ghcr.io/toolkithub/rce-images-csharp";
 
   installedPackages = [
     pkgs.mono

--- a/images/dart.nix
+++ b/images/dart.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/dart";
+  name = "ghcr.io/toolkithub/rce-image-dart";
 
   installedPackages = [
     pkgs.dart

--- a/images/dart.nix
+++ b/images/dart.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-dart";
+  name = "ghcr.io/toolkithub/rce-images-dart";
 
   installedPackages = [
     pkgs.dart

--- a/images/dlang.nix
+++ b/images/dlang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-dlang";
+  name = "ghcr.io/toolkithub/rce-images-dlang";
 
   installedPackages = [
     pkgs.dmd

--- a/images/dlang.nix
+++ b/images/dlang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/dlang";
+  name = "ghcr.io/toolkithub/rce-image-dlang";
 
   installedPackages = [
     pkgs.dmd

--- a/images/elixir.nix
+++ b/images/elixir.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-elixir";
+  name = "ghcr.io/toolkithub/rce-images-elixir";
 
   installedPackages = [
     pkgs.elixir

--- a/images/elixir.nix
+++ b/images/elixir.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/elixir";
+  name = "ghcr.io/toolkithub/rce-image-elixir";
 
   installedPackages = [
     pkgs.elixir

--- a/images/elm.nix
+++ b/images/elm.nix
@@ -13,7 +13,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-elm";
+  name = "ghcr.io/toolkithub/rce-images-elm";
 
   installedPackages = [
     pkgs.elmPackages.elm

--- a/images/elm.nix
+++ b/images/elm.nix
@@ -13,7 +13,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/elm";
+  name = "ghcr.io/toolkithub/rce-image-elm";
 
   installedPackages = [
     pkgs.elmPackages.elm

--- a/images/erlang.nix
+++ b/images/erlang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-erlang";
+  name = "ghcr.io/toolkithub/rce-images-erlang";
 
   installedPackages = [
     pkgs.erlang

--- a/images/erlang.nix
+++ b/images/erlang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/erlang";
+  name = "ghcr.io/toolkithub/rce-image-erlang";
 
   installedPackages = [
     pkgs.erlang

--- a/images/fsharp.nix
+++ b/images/fsharp.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/fsharp";
+  name = "ghcr.io/toolkithub/rce-image-fsharp";
 
   installedPackages = [
     pkgs.mono

--- a/images/fsharp.nix
+++ b/images/fsharp.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-fsharp";
+  name = "ghcr.io/toolkithub/rce-images-fsharp";
 
   installedPackages = [
     pkgs.mono

--- a/images/golang.nix
+++ b/images/golang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-golang";
+  name = "ghcr.io/toolkithub/rce-images-golang";
 
   installedPackages = [
     pkgs.go

--- a/images/golang.nix
+++ b/images/golang.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/golang";
+  name = "ghcr.io/toolkithub/rce-image-golang";
 
   installedPackages = [
     pkgs.go

--- a/images/groovy.nix
+++ b/images/groovy.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/groovy";
+  name = "ghcr.io/toolkithub/rce-image-groovy";
 
   installedPackages = [
     pkgs.gawk

--- a/images/groovy.nix
+++ b/images/groovy.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-groovy";
+  name = "ghcr.io/toolkithub/rce-images-groovy";
 
   installedPackages = [
     pkgs.gawk

--- a/images/guile.nix
+++ b/images/guile.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/guile";
+  name = "ghcr.io/toolkithub/rce-image-guile";
 
   installedPackages = [
     pkgs.guile

--- a/images/guile.nix
+++ b/images/guile.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-guile";
+  name = "ghcr.io/toolkithub/rce-images-guile";
 
   installedPackages = [
     pkgs.guile

--- a/images/hare.nix
+++ b/images/hare.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-hare";
+  name = "ghcr.io/toolkithub/rce-images-hare";
 
   installedPackages = [
     pkgs.hare

--- a/images/hare.nix
+++ b/images/hare.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/hare";
+  name = "ghcr.io/toolkithub/rce-image-hare";
 
   installedPackages = [
     pkgs.hare

--- a/images/haskell.nix
+++ b/images/haskell.nix
@@ -51,7 +51,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-haskell";
+  name = "ghcr.io/toolkithub/rce-images-haskell";
 
   installedPackages = [
     haskellPackages

--- a/images/haskell.nix
+++ b/images/haskell.nix
@@ -51,7 +51,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/haskell";
+  name = "ghcr.io/toolkithub/rce-image-haskell";
 
   installedPackages = [
     haskellPackages

--- a/images/idris.nix
+++ b/images/idris.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/idris";
+  name = "ghcr.io/toolkithub/rce-image-idris";
 
   installedPackages = [
     pkgs.idris2

--- a/images/idris.nix
+++ b/images/idris.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-idris";
+  name = "ghcr.io/toolkithub/rce-images-idris";
 
   installedPackages = [
     pkgs.idris2

--- a/images/java.nix
+++ b/images/java.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/java";
+  name = "ghcr.io/toolkithub/rce-image-java";
 
   installedPackages = [
     pkgs.jdk

--- a/images/java.nix
+++ b/images/java.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-java";
+  name = "ghcr.io/toolkithub/rce-images-java";
 
   installedPackages = [
     pkgs.jdk

--- a/images/javascript.nix
+++ b/images/javascript.nix
@@ -10,7 +10,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-javascript";
+  name = "ghcr.io/toolkithub/rce-images-javascript";
 
   installedPackages = [
     pkgs.nodejs

--- a/images/javascript.nix
+++ b/images/javascript.nix
@@ -10,7 +10,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/javascript";
+  name = "ghcr.io/toolkithub/rce-image-javascript";
 
   installedPackages = [
     pkgs.nodejs

--- a/images/julia.nix
+++ b/images/julia.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-julia";
+  name = "ghcr.io/toolkithub/rce-images-julia";
 
   installedPackages = [
     pkgs.julia

--- a/images/julia.nix
+++ b/images/julia.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/julia";
+  name = "ghcr.io/toolkithub/rce-image-julia";
 
   installedPackages = [
     pkgs.julia

--- a/images/kotlin.nix
+++ b/images/kotlin.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-kotlin";
+  name = "ghcr.io/toolkithub/rce-images-kotlin";
 
   installedPackages = [
     pkgs.kotlin

--- a/images/kotlin.nix
+++ b/images/kotlin.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/kotlin";
+  name = "ghcr.io/toolkithub/rce-image-kotlin";
 
   installedPackages = [
     pkgs.kotlin

--- a/images/lua.nix
+++ b/images/lua.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/lua";
+  name = "ghcr.io/toolkithub/rce-image-lua";
 
   installedPackages = [
     pkgs.lua

--- a/images/lua.nix
+++ b/images/lua.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-lua";
+  name = "ghcr.io/toolkithub/rce-images-lua";
 
   installedPackages = [
     pkgs.lua

--- a/images/mercury.nix
+++ b/images/mercury.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/mercury";
+  name = "ghcr.io/toolkithub/rce-image-mercury";
 
   installedPackages = [
     pkgs.mercury

--- a/images/mercury.nix
+++ b/images/mercury.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-mercury";
+  name = "ghcr.io/toolkithub/rce-images-mercury";
 
   installedPackages = [
     pkgs.mercury

--- a/images/nim.nix
+++ b/images/nim.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-nim";
+  name = "ghcr.io/toolkithub/rce-images-nim";
 
   installedPackages = [
     pkgs.gcc

--- a/images/nim.nix
+++ b/images/nim.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/nim";
+  name = "ghcr.io/toolkithub/rce-image-nim";
 
   installedPackages = [
     pkgs.gcc

--- a/images/nix.nix
+++ b/images/nix.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-nix";
+  name = "ghcr.io/toolkithub/rce-images-nix";
 
   installedPackages = [
     pkgs.nix

--- a/images/nix.nix
+++ b/images/nix.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/nix";
+  name = "ghcr.io/toolkithub/rce-image-nix";
 
   installedPackages = [
     pkgs.nix

--- a/images/ocaml.nix
+++ b/images/ocaml.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-ocaml";
+  name = "ghcr.io/toolkithub/rce-images-ocaml";
 
   installedPackages = [
     pkgs.ocaml

--- a/images/ocaml.nix
+++ b/images/ocaml.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/ocaml";
+  name = "ghcr.io/toolkithub/rce-image-ocaml";
 
   installedPackages = [
     pkgs.ocaml

--- a/images/pascal.nix
+++ b/images/pascal.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-pascal";
+  name = "ghcr.io/toolkithub/rce-images-pascal";
 
   installedPackages = [
     pkgs.binutils

--- a/images/pascal.nix
+++ b/images/pascal.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/pascal";
+  name = "ghcr.io/toolkithub/rce-image-pascal";
 
   installedPackages = [
     pkgs.binutils

--- a/images/perl.nix
+++ b/images/perl.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-perl";
+  name = "ghcr.io/toolkithub/rce-images-perl";
 
   installedPackages = [
     pkgs.perl

--- a/images/perl.nix
+++ b/images/perl.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/perl";
+  name = "ghcr.io/toolkithub/rce-image-perl";
 
   installedPackages = [
     pkgs.perl

--- a/images/php.nix
+++ b/images/php.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-php";
+  name = "ghcr.io/toolkithub/rce-images-php";
 
   installedPackages = [
     pkgs.php

--- a/images/php.nix
+++ b/images/php.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/php";
+  name = "ghcr.io/toolkithub/rce-image-php";
 
   installedPackages = [
     pkgs.php

--- a/images/python.nix
+++ b/images/python.nix
@@ -17,7 +17,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-python";
+  name = "ghcr.io/toolkithub/rce-images-python";
 
   installedPackages = [
     pythonPackages

--- a/images/python.nix
+++ b/images/python.nix
@@ -17,7 +17,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/python";
+  name = "ghcr.io/toolkithub/rce-image-python";
 
   installedPackages = [
     pythonPackages

--- a/images/raku.nix
+++ b/images/raku.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-raku";
+  name = "ghcr.io/toolkithub/rce-images-raku";
 
   installedPackages = [
     pkgs.rakudo

--- a/images/raku.nix
+++ b/images/raku.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/raku";
+  name = "ghcr.io/toolkithub/rce-image-raku";
 
   installedPackages = [
     pkgs.rakudo

--- a/images/ruby.nix
+++ b/images/ruby.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/ruby";
+  name = "ghcr.io/toolkithub/rce-image-ruby";
 
   installedPackages = [
     pkgs.ruby

--- a/images/ruby.nix
+++ b/images/ruby.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-ruby";
+  name = "ghcr.io/toolkithub/rce-images-ruby";
 
   installedPackages = [
     pkgs.ruby

--- a/images/rust.nix
+++ b/images/rust.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rust";
+  name = "ghcr.io/toolkithub/rce-image-rust";
 
   installedPackages = [
     pkgs.binutils

--- a/images/rust.nix
+++ b/images/rust.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-rust";
+  name = "ghcr.io/toolkithub/rce-images-rust";
 
   installedPackages = [
     pkgs.binutils

--- a/images/sac.nix
+++ b/images/sac.nix
@@ -17,7 +17,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/sac";
+  name = "ghcr.io/toolkithub/rce-image-sac";
 
   installedPackages = [
     pkgs.gcc

--- a/images/sac.nix
+++ b/images/sac.nix
@@ -17,7 +17,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-sac";
+  name = "ghcr.io/toolkithub/rce-images-sac";
 
   installedPackages = [
     pkgs.gcc

--- a/images/scala.nix
+++ b/images/scala.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-scala";
+  name = "ghcr.io/toolkithub/rce-images-scala";
 
   installedPackages = [
     pkgs.scala

--- a/images/scala.nix
+++ b/images/scala.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/scala";
+  name = "ghcr.io/toolkithub/rce-image-scala";
 
   installedPackages = [
     pkgs.scala

--- a/images/swift.nix
+++ b/images/swift.nix
@@ -14,7 +14,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/swift";
+  name = "ghcr.io/toolkithub/rce-image-swift";
 
   installedPackages = [
     pkgs.binutils

--- a/images/swift.nix
+++ b/images/swift.nix
@@ -14,7 +14,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-swift";
+  name = "ghcr.io/toolkithub/rce-images-swift";
 
   installedPackages = [
     pkgs.binutils

--- a/images/typescript.nix
+++ b/images/typescript.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-typescript";
+  name = "ghcr.io/toolkithub/rce-images-typescript";
 
   installedPackages = [
     pkgs.nodePackages.typescript

--- a/images/typescript.nix
+++ b/images/typescript.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/typescript";
+  name = "ghcr.io/toolkithub/rce-image-typescript";
 
   installedPackages = [
     pkgs.nodePackages.typescript

--- a/images/zig.nix
+++ b/images/zig.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/rce-image-zig";
+  name = "ghcr.io/toolkithub/rce-images-zig";
 
   installedPackages = [
     pkgs.zig

--- a/images/zig.nix
+++ b/images/zig.nix
@@ -7,7 +7,7 @@ let
 in
 build_image {
   pkgs = pkgs;
-  name = "ghcr.io/toolkithub/zig";
+  name = "ghcr.io/toolkithub/rce-image-zig";
 
   installedPackages = [
     pkgs.zig

--- a/scripts/build_batch_1.sh
+++ b/scripts/build_batch_1.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-assembly images/assembly.nix
-# nix-build --out-link result/rce-image-ats images/ats.nix
-# nix-build --out-link result/rce-image-bash images/bash.nix
+nix-build --out-link result/rce-images-assembly images/assembly.nix
+# nix-build --out-link result/rce-images-ats images/ats.nix
+# nix-build --out-link result/rce-images-bash images/bash.nix

--- a/scripts/build_batch_1.sh
+++ b/scripts/build_batch_1.sh
@@ -3,5 +3,5 @@ set -e
 
 mkdir -p result
 nix-build --out-link result/rce-images-assembly images/assembly.nix
-# nix-build --out-link result/rce-images-ats images/ats.nix
-# nix-build --out-link result/rce-images-bash images/bash.nix
+nix-build --out-link result/rce-images-ats images/ats.nix
+nix-build --out-link result/rce-images-bash images/bash.nix

--- a/scripts/build_batch_10.sh
+++ b/scripts/build_batch_10.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-lua images/lua.nix
-nix-build --out-link result/rce-image-nim images/nim.nix
-nix-build --out-link result/rce-image-nix images/nix.nix
+nix-build --out-link result/rce-images-lua images/lua.nix
+nix-build --out-link result/rce-images-nim images/nim.nix
+nix-build --out-link result/rce-images-nix images/nix.nix

--- a/scripts/build_batch_2.sh
+++ b/scripts/build_batch_2.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-clang images/clang.nix
-nix-build --out-link result/rce-image-clisp images/clisp.nix
-nix-build --out-link result/rce-image-clojure images/clojure.nix
+nix-build --out-link result/rce-images-clang images/clang.nix
+nix-build --out-link result/rce-images-clisp images/clisp.nix
+nix-build --out-link result/rce-images-clojure images/clojure.nix

--- a/scripts/build_batch_3.sh
+++ b/scripts/build_batch_3.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-dart images/dart.nix
-nix-build --out-link result/rce-image-elixir images/elixir.nix
-nix-build --out-link result/rce-image-elm images/elm.nix
+nix-build --out-link result/rce-images-dart images/dart.nix
+nix-build --out-link result/rce-images-elixir images/elixir.nix
+nix-build --out-link result/rce-images-elm images/elm.nix

--- a/scripts/build_batch_4.sh
+++ b/scripts/build_batch_4.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-groovy images/groovy.nix
-nix-build --out-link result/rce-image-guile images/guile.nix
-nix-build --out-link result/rce-image-hare images/hare.nix
+nix-build --out-link result/rce-images-groovy images/groovy.nix
+nix-build --out-link result/rce-images-guile images/guile.nix
+nix-build --out-link result/rce-images-hare images/hare.nix

--- a/scripts/build_batch_5.sh
+++ b/scripts/build_batch_5.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-java images/java.nix
-nix-build --out-link result/rce-image-javascript images/javascript.nix
-nix-build --out-link result/rce-image-julia images/julia.nix
+nix-build --out-link result/rce-images-java images/java.nix
+nix-build --out-link result/rce-images-javascript images/javascript.nix
+nix-build --out-link result/rce-images-julia images/julia.nix

--- a/scripts/build_batch_6.sh
+++ b/scripts/build_batch_6.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-mercury images/mercury.nix
-nix-build --out-link result/rce-image-csharp images/csharp.nix
-nix-build --out-link result/rce-image-fsharp images/fsharp.nix
+nix-build --out-link result/rce-images-mercury images/mercury.nix
+nix-build --out-link result/rce-images-csharp images/csharp.nix
+nix-build --out-link result/rce-images-fsharp images/fsharp.nix

--- a/scripts/build_batch_7.sh
+++ b/scripts/build_batch_7.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-cobol images/cobol.nix
-nix-build --out-link result/rce-image-coffeescript images/coffeescript.nix
-nix-build --out-link result/rce-image-crystal images/crystal.nix
+nix-build --out-link result/rce-images-cobol images/cobol.nix
+nix-build --out-link result/rce-images-coffeescript images/coffeescript.nix
+nix-build --out-link result/rce-images-crystal images/crystal.nix

--- a/scripts/build_batch_8.sh
+++ b/scripts/build_batch_8.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-dlang images/dlang.nix
-nix-build --out-link result/rce-image-erlang images/erlang.nix
-nix-build --out-link result/rce-image-golang images/golang.nix
+nix-build --out-link result/rce-images-dlang images/dlang.nix
+nix-build --out-link result/rce-images-erlang images/erlang.nix
+nix-build --out-link result/rce-images-golang images/golang.nix

--- a/scripts/build_batch_9.sh
+++ b/scripts/build_batch_9.sh
@@ -2,6 +2,6 @@
 set -e
 
 mkdir -p result
-nix-build --out-link result/rce-image-haskell images/haskell.nix
-nix-build --out-link result/rce-image-idris images/idris.nix
-nix-build --out-link result/rce-image-kotlin images/kotlin.nix
+nix-build --out-link result/rce-images-haskell images/haskell.nix
+nix-build --out-link result/rce-images-idris images/idris.nix
+nix-build --out-link result/rce-images-kotlin images/kotlin.nix

--- a/scripts/push_all.sh
+++ b/scripts/push_all.sh
@@ -2,7 +2,7 @@
 set -e
 
 for image in result/*; do
-	name="ghcr.io/toolkithub/$(basename "${image}")"
+	name="ghcr.io/toolkithub/$(basename "${image}"):edge"
 
 	echo "Pushing ${name}..."
 	docker push "${name}"


### PR DESCRIPTION
This pull request fixes an issue where an "image not found" error occurs when pushing to ghcr. The changes include updating the image names for various languages, such as ATS, Lua, Nim, Nix, PHP, Zig, Java, SAC, Dart, Hare, Perl, Ruby, Cobol, Dlang, Bash, Clisp, Golang, Raku, Clang, Guile, Julia, OCaml, Scala, C#, F#, Groovy, Idris, Rust, Elixir, Erlang, Kotlin, Pascal, Swift, Crystal, Mercury, Clojure, Elm, Python, Assembly, and Haskell. The new image names are prefixed with "rce-image-".